### PR TITLE
[#22] Add CMS-concurrent-* gc events parsing.

### DIFF
--- a/common/src/main/proto/gc_model.proto
+++ b/common/src/main/proto/gc_model.proto
@@ -10,15 +10,19 @@ message GcEvent {
         MINOR_GC = 2;                           // Minor gc
         CMS_INIT_MARK = 3;                      // CMS initial mark phase
         CMS_FINAL_REMARK = 4;                   // CMS final remark phase
+        CMS_CONCURRENT = 5;                     // CMS concurrent
     }
 
     uint32 thread = 1;                          // thread ID
     uint64 timestamp = 2;                       // time stamp(time since JVM startup)
     string datetime = 3;                        // utc time
     LogType log_type = 4;                       // log type
-    double pause_time = 5;                       // duration of GC event in seconds
-    double user_time = 6;                        // total CPU time of GC event
-    double sys_time = 7;                         // time spent in OS call or waiting for system event
-    double real_time = 8;                        // (user_time + sys_tim) / threads# + alpha
-    double ref_time = 9;                         // reference processing time
+    double pause_time = 5;                      // duration of GC event in seconds
+    double user_time = 6;                       // total CPU time of GC event
+    double sys_time = 7;                        // time spent in OS call or waiting for system event
+    double real_time = 8;                       // (user_time + sys_tim) / threads# + alpha
+    double ref_time = 9;                        // reference processing time
+    double cms_cpu_time = 10;                   // CMS concurrent event cpu time
+    double cms_wall_time = 11;                  // CMS concurrent event wall time
+    string type_detail = 12;                     // detailed type info
 }

--- a/parser/src/main/java/edu/kaist/algo/parser/GcEventNode.java
+++ b/parser/src/main/java/edu/kaist/algo/parser/GcEventNode.java
@@ -1,6 +1,7 @@
 package edu.kaist.algo.parser;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nullable;
@@ -27,6 +28,10 @@ public abstract class GcEventNode {
   @Nullable public abstract Double sys();
 
   @Nullable public abstract Double real();
+
+  @Nullable public abstract Double cmsCpuTime();
+
+  @Nullable public abstract Double cmsWallTime();
 
   public abstract ImmutableList<GcEventNode> children();
 
@@ -57,6 +62,10 @@ public abstract class GcEventNode {
 
     public abstract Builder real(Double real);
 
+    public abstract Builder cmsCpuTime(Double cpuTime);
+
+    public abstract Builder cmsWallTime(Double wallTime);
+
     abstract ImmutableList.Builder<GcEventNode> childrenBuilder();
 
     public Builder addChild(GcEventNode child) {
@@ -65,5 +74,13 @@ public abstract class GcEventNode {
     }
 
     public abstract GcEventNode build();
+  }
+
+  public String typeAndDetail() {
+    final StringBuilder sb = new StringBuilder(type());
+    if (!Strings.isNullOrEmpty(detail())) {
+      sb.append(" (").append(detail()).append(")");
+    }
+    return sb.toString();
   }
 }


### PR DESCRIPTION
- CMS_CONCURRENT LogType added on gc_model.
- CMS concurrent cpu time, wall time added.
- Avoid potential NPE on CmsLogParser#parseGcEvent.
