### PR TITLE
[#47] Fix LogUtilTest failure - wrong import statement.

### DIFF
--- a/cli-client/src/main/java/edu/kaist/algo/client/LogUploadClient.java
+++ b/cli-client/src/main/java/edu/kaist/algo/client/LogUploadClient.java
@@ -2,14 +2,14 @@ package edu.kaist.algo.client;
 
 import static com.google.protobuf.ByteString.readFrom;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.ByteString;
+
 import edu.kaist.algo.service.FileInfo;
 import edu.kaist.algo.service.FileUploadResult;
 import edu.kaist.algo.service.LogUploadGrpc;
 import edu.kaist.algo.service.UploadRequest;
 import edu.kaist.algo.service.UploadResult;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.protobuf.ByteString;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;

--- a/cli-client/src/main/java/edu/kaist/algo/client/LogUtil.java
+++ b/cli-client/src/main/java/edu/kaist/algo/client/LogUtil.java
@@ -1,9 +1,9 @@
 package edu.kaist.algo.client;
 
-import edu.kaist.algo.model.GcAnalyzedData;
+import edu.kaist.algo.analysis.GcAnalyzedData;
+import edu.kaist.algo.analysis.GcPauseOutliers;
+import edu.kaist.algo.analysis.GcPauseStat;
 import edu.kaist.algo.model.GcEvent;
-import edu.kaist.algo.model.GcPauseOutliers;
-import edu.kaist.algo.model.GcPauseStat;
 
 import com.jakewharton.fliptables.FlipTableConverters;
 

--- a/cli-client/src/test/java/edu/kaist/algo/client/LogUtilTest.java
+++ b/cli-client/src/test/java/edu/kaist/algo/client/LogUtilTest.java
@@ -2,8 +2,8 @@ package edu.kaist.algo.client;
 
 import static org.junit.Assert.assertEquals;
 
+import edu.kaist.algo.analysis.GcAnalyzedData;
 import edu.kaist.algo.analyzer.LogAnalyzer;
-import edu.kaist.algo.model.GcAnalyzedData;
 import edu.kaist.algo.model.GcEvent;
 
 import org.junit.Before;


### PR DESCRIPTION
There has been a failing test after pulling PR #46 in LogUtilTest.
The import statements have not been updated according to changes.

All appearances of `edu.kaist.algo.model.GcAnalyzedData` should become `edu.kaist.algo.analysis.GcAnalyzedData`.
