### PR TITLE
[#34] Integrated Ticketer class into LogUploadImpl

### DIFF
--- a/api/src/main/java/edu/kaist/algo/api/LogUploadImpl.java
+++ b/api/src/main/java/edu/kaist/algo/api/LogUploadImpl.java
@@ -1,33 +1,48 @@
 package edu.kaist.algo.api;
 
+import static edu.kaist.algo.api.Ticketer.Status.NOT_READY;
+
 import com.google.protobuf.ByteString;
 
 import edu.kaist.algo.service.FileInfo;
-import edu.kaist.algo.service.FileUploadResult;
+import edu.kaist.algo.service.FileInfoResult;
 import edu.kaist.algo.service.LogUploadGrpc;
 import edu.kaist.algo.service.UploadRequest;
 import edu.kaist.algo.service.UploadResult;
 
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+
+import org.apache.commons.io.FileExistsException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
- * Defines a service that receives a stream of logfile and creating a file on
- * the server.
+ * Defines a service that firstly receives the information about
+ * the file to be uploaded, and then receives a stream of logfile
+ * contents and writes on a file on the server.
  */
 public class LogUploadImpl implements LogUploadGrpc.LogUpload {
   private static final Logger logger =
       LoggerFactory.getLogger(LogUploadImpl.class);
-  File uploadedFile;
+  private final Ticketer ticketer;
+  private final Map<Long, FileOutputStream> ticketToFos = new HashMap<>();
+
+  /**
+   * Creates LogUploadImpl instance.
+   * @param ticketer the ticketer instance to use for redis interactions
+   */
+  LogUploadImpl(Ticketer ticketer) {
+    this.ticketer = ticketer;
+  }
 
   /**
    * Single-shot gRPC service receiving file information from the client.
@@ -35,26 +50,31 @@ public class LogUploadImpl implements LogUploadGrpc.LogUpload {
    * <p>From the file name, a new file is created. Resulting file
    * is used to write contents received from the client in
    * logUpload() method.
+   *
    * @param fileinfo The file information such as file name, date, etc.
    * @param responseObserver StreamObserver type from client.
    */
   @Override
   public void infoUpload(FileInfo fileinfo,
-                         StreamObserver<FileUploadResult> responseObserver) {
-    responseObserver.onNext(openNewFile(fileinfo.getFilename()));
-    responseObserver.onCompleted();
-  }
+                         StreamObserver<FileInfoResult> responseObserver) {
+    File uploadedFile = new File(FilenameUtils.getName(fileinfo.getFilename()));
 
-  /**
-   * Opens up a new file given by the filename.
-   * The file must not exit already.
-   * @param filename the filename (full directory name is OK) of a new file.
-   * @return The new file opened only by the filename, without the directory.
-   */
-  private FileUploadResult openNewFile(String filename) {
-    uploadedFile = new File(FilenameUtils.getName(filename));
-    return FileUploadResult.newBuilder()
-        .setSuccessful(uploadedFile.exists()).build();
+    // file should not already exist
+    if (uploadedFile.exists()) {
+      responseObserver.onError(new FileExistsException());
+    } else {
+      long ticket = ticketer.issueTicket();
+      ticketer.setLogFile(ticket, uploadedFile.getName());
+      ticketer.setStatus(ticket, NOT_READY);
+
+      FileInfoResult result = FileInfoResult.newBuilder()
+          .setSuccessful(true)
+          .setId(ticket)
+          .build();
+
+      responseObserver.onNext(result);
+      responseObserver.onCompleted();
+    }
   }
 
   /**
@@ -67,28 +87,30 @@ public class LogUploadImpl implements LogUploadGrpc.LogUpload {
   public StreamObserver<UploadRequest> logUpload(
       final StreamObserver<UploadResult> responseObserver) {
 
-    FileOutputStream outputstream;
-    try {
-      outputstream = FileUtils.openOutputStream(uploadedFile);
-    } catch (FileNotFoundException fnfe) {
-      logger.error("File cannot be created or cannot be opened.", fnfe);
-      return null;
-    } catch (IOException ioe) {
-      logger.error("Could not open file output stream.", ioe);
-      return null;
-    }
-
     return new StreamObserver<UploadRequest>() {
+      private long ticketNum;
       int totalsize = 0;
-      int id = 1; // temporary default number
-      private UploadResult result;
 
       @Override
       public void onNext(UploadRequest uploadrequest) {
+        ticketNum = uploadrequest.getId();
+
+        FileOutputStream fos = ticketToFos.get(ticketNum);
+        if (fos == null) {
+          try {
+            fos = FileUtils.openOutputStream(new File(ticketer.getLogFile(ticketNum)));
+          } catch (IOException ioe) {
+            logger.error("Could not open file.", ioe);
+            responseObserver.onCompleted();
+            return;
+          }
+          ticketToFos.put(ticketNum, fos);
+        }
+
         ByteString bytestring = uploadrequest.getContents();
         int size = bytestring.size();
         try {
-          bytestring.writeTo(outputstream);
+          bytestring.writeTo(fos);
         } catch (IOException ie) {
           logger.error("Error occurred during file receiving : " + ie.getMessage());
         }
@@ -99,17 +121,24 @@ public class LogUploadImpl implements LogUploadGrpc.LogUpload {
       public void onError(Throwable thrown) {
         Status status = Status.fromThrowable(thrown);
         logger.error("Log receiving failed : " + status.getDescription());
-        result = UploadResult.newBuilder().setFilesize(totalsize)
-            .setId(id).setSuccessful(false).build();
+        ticketer.deleteResource(ticketNum);
+        ticketToFos.remove(ticketNum);
+
+        UploadResult result = UploadResult.newBuilder().setFilesize(totalsize)
+            .setSuccessful(false).build();
         responseObserver.onNext(result);
       }
 
       @Override
       public void onCompleted() {
-        // build Upload Result
-        uploadedFile = null;
-        result = UploadResult.newBuilder().setFilesize(totalsize)
-            .setId(id).setSuccessful(true).build();
+        ticketToFos.remove(ticketNum);
+
+        ticketer.setMeta(ticketNum, ticketer.getLogFile(ticketNum), totalsize);
+
+        UploadResult result = UploadResult.newBuilder()
+            .setFilesize(totalsize)
+            .setSuccessful(true)
+            .build();
         responseObserver.onNext(result);
         responseObserver.onCompleted();
       }

--- a/api/src/test/java/edu/kaist/algo/api/TicketerTest.java
+++ b/api/src/test/java/edu/kaist/algo/api/TicketerTest.java
@@ -2,18 +2,22 @@ package edu.kaist.algo.api;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.fiftyonred.mock_jedis.MockJedisPool;
+import com.google.common.collect.ImmutableMap;
 
+import com.fiftyonred.mock_jedis.MockJedisPool;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
+
+import java.util.Map;
+
 
 /**
  * Test the Ticketer class by using a MockJedis class so that
@@ -24,8 +28,8 @@ public class TicketerTest {
   private static final Ticketer.Status EXAMPLE_STATUS =
       Ticketer.Status.ANALYZING;
   private static final String EXAMPLE_LOGFILE = "example.log";
-  private static final String EXAMPLE_META = "metafile";
   private static final String EXAMPLE_RESULT = "resultfile";
+  private static final long EXAMPLE_SIZE = 6778;
 
   private static Ticketer ticketer;
   private static long ticket;
@@ -40,9 +44,9 @@ public class TicketerTest {
     ticketer = new Ticketer(jedisPool); // MockJedisPool constructor
     ticket = ticketer.issueTicket(); // this should be 1
     ticketer.setLogFile(ticket, EXAMPLE_LOGFILE);
-    ticketer.setMeta(ticket, EXAMPLE_META);
     ticketer.setResult(ticket, EXAMPLE_RESULT);
     ticketer.setStatus(ticket, EXAMPLE_STATUS);
+    ticketer.setMeta(ticket, EXAMPLE_LOGFILE, EXAMPLE_SIZE);
   }
 
   // issues another ticket and checks its value
@@ -109,8 +113,12 @@ public class TicketerTest {
     String logfileName = ticketer.getLogFile(ticket);
     assertEquals(EXAMPLE_LOGFILE, logfileName);
 
-    String metafileName = ticketer.getMeta(ticket);
-    assertEquals(EXAMPLE_META, metafileName);
+    Map<String, String> metaKey = ticketer.getMeta(ticket);
+    Map<String, String> data = ImmutableMap.of(
+        Ticketer.META_NAME, EXAMPLE_LOGFILE,
+        Ticketer.META_SIZE, String.valueOf(EXAMPLE_SIZE)
+    );
+    assertEquals(data, metaKey);
 
     String resultName = ticketer.getResult(ticket);
     assertEquals(EXAMPLE_RESULT, resultName);
@@ -128,8 +136,8 @@ public class TicketerTest {
     String logfileName = ticketer.getLogFile(ticket);
     assertNull(logfileName);
 
-    String metafileName = ticketer.getMeta(ticket);
-    assertNull(metafileName);
+    Map<String, String> metaKey = ticketer.getMeta(ticket);
+    assertTrue(metaKey.isEmpty());
 
     String resultName = ticketer.getResult(ticket);
     assertNull(resultName);

--- a/cli-client/src/main/java/edu/kaist/algo/client/GcToolClient.java
+++ b/cli-client/src/main/java/edu/kaist/algo/client/GcToolClient.java
@@ -191,12 +191,12 @@ public class GcToolClient {
     }
 
     // give the filename to server to open on server
-    logUploader.uploadInfo(parsedOptions.getFilename());
+    long ticket = logUploader.uploadInfo(parsedOptions.getFilename());
 
     // Send and upload the file
     try {
       FileInputStream inputStream = FileUtils.openInputStream(logfile);
-      logUploader.uploadLog(inputStream);
+      logUploader.uploadLog(ticket, inputStream);
     } catch (InterruptedException ie) {
       System.out.println("File upload failed due to interruption.");
     } catch (IOException ioe) {

--- a/cli-client/src/main/java/edu/kaist/algo/client/LogUploader.java
+++ b/cli-client/src/main/java/edu/kaist/algo/client/LogUploader.java
@@ -6,7 +6,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.ByteString;
 
 import edu.kaist.algo.service.FileInfo;
-import edu.kaist.algo.service.FileUploadResult;
+import edu.kaist.algo.service.FileInfoResult;
 import edu.kaist.algo.service.LogUploadGrpc;
 import edu.kaist.algo.service.UploadRequest;
 import edu.kaist.algo.service.UploadResult;
@@ -44,14 +44,37 @@ public class LogUploader {
   }
 
   /**
+   * Send meta-information about the file to be uploaded.
+   * Receives the success status and file identification number.
+   * @param filename indicate the file name to be stored on server.
+   * @return the ticket number
+   */
+  public long uploadInfo(String filename) {
+    FileInfo fileinfo = FileInfo.newBuilder().setFilename(filename).build();
+    long ticketNum = 0;
+
+    try {
+      FileInfoResult result = blockingStub.infoUpload(fileinfo);
+      ticketNum = result.getId();
+      System.out.println("File to write on opened on server : " + result.getSuccessful());
+      System.out.println("File ID : " + ticketNum);
+    } catch (StatusRuntimeException event) {
+      logger.error("infoUpload failed : ", event.getStatus());
+    }
+    return ticketNum;
+  }
+
+  /**
    * Creates a responseObserver that can be used in the server,
    * and uses an uploadObserver to stream file contents to the server until it is empty.
    * When the upload is done, the server sends the results as UploadResult class,
    * which responseObserver uses to print out the upload summary.
+   *
+   * @param ticketNum the ticket number for file identification
    * @param inputStream File input stream to read in contents of file.
    * @throws InterruptedException Thrown when upload stream is interrupted.
    */
-  public void uploadLog(FileInputStream inputStream) throws InterruptedException {
+  public void uploadLog(long ticketNum, FileInputStream inputStream) throws InterruptedException {
     System.out.println("***Upload logfile***");
 
     StreamObserver<UploadResult> responseObserver = new StreamObserver<UploadResult>() {
@@ -59,14 +82,14 @@ public class LogUploader {
       public void onNext(UploadResult result) {
         System.out.println("***Upload Result Summary***");
         System.out.println("Successful : " + result.getSuccessful());
-        System.out.println("File ID : " + result.getId());
+        System.out.println("File ID : " + ticketNum);
         System.out.println("Total Received File Size : " + result.getFilesize());
       }
 
       @Override
       public void onError(Throwable thrown) {
         Status status = Status.fromThrowable(thrown);
-        System.err.println("***Log Upload Failed" + thrown.getMessage());
+        System.err.println("***Log Upload Failed" + status.toString());
       }
 
       @Override
@@ -84,7 +107,7 @@ public class LogUploader {
       while (true) {
         bytestring = readFrom(inputStream, BUFFER_SIZE);
         UploadRequest uploadrequest = UploadRequest.newBuilder()
-            .setContents(bytestring).build();
+            .setId(ticketNum).setContents(bytestring).build();
         uploadObserver.onNext(uploadrequest);
 
         // show progress
@@ -103,21 +126,6 @@ public class LogUploader {
 
     // upload finished
     uploadObserver.onCompleted();
-  }
-
-  /**
-   * Send meta-information about the file to be uploaded.
-   * @param filename The file name to upload.
-   */
-  public void uploadInfo(String filename) {
-    FileInfo fileinfo = FileInfo.newBuilder().setFilename(filename).build();
-
-    try {
-      FileUploadResult result = blockingStub.infoUpload(fileinfo);
-      System.out.println("File to write on opened on server : " + result.getSuccessful());
-    } catch (StatusRuntimeException event) {
-      logger.error("infoUpload failed : ", event.getStatus());
-    }
   }
 
   /**

--- a/common/src/main/proto/gc_service.proto
+++ b/common/src/main/proto/gc_service.proto
@@ -8,7 +8,7 @@ import "gc_analysis.proto";
 // The client streams the file contents to the server,
 // and requests for the result status.
 service LogUpload {
-  rpc InfoUpload (FileInfo) returns (FileUploadResult) {}
+  rpc InfoUpload (FileInfo) returns (FileInfoResult) {}
   rpc LogUpload (stream UploadRequest) returns (UploadResult) {}
 }
 
@@ -17,20 +17,22 @@ message FileInfo {
   string filename = 1;
 }
 
-// The result of receiving information and opening the file.
-message FileUploadResult {
+// tells whether the file info was uploaded properly, and returns
+// the identification number
+message FileInfoResult {
   bool successful = 1;
+  int64 id = 2;
 }
 
-// The file name to upload.
+// The file contents to upload on file ID.
 message UploadRequest {
-  bytes contents = 1;
+  int64 id = 1;
+  bytes contents = 2;
 }
 
 // The response contains whether the request was successful and
 // the requestID for further identification uses.
 message UploadResult {
   bool successful = 1;
-  int32 id = 2;
-  int64 filesize = 3;
+  int64 filesize = 2;
 }


### PR DESCRIPTION
### Integrated Ticketer class into LogUploadImpl.

See issue [#34]
- GcToolServer now needs a local redis server on.
- Issues a ticket every time a file is uploaded - no longer issues default fileID.
- Defined a new protobuf message MetaInfo.
- Now creates a protobuf-encoded binary file containing metadata. File name is `meta_<fileID>`.
- Added tests that checks proper creation of metafile.
