### PR TITLE
[#55] Build cli-client with fat-jar.

### DIFF
--- a/cli-client/build.gradle
+++ b/cli-client/build.gradle
@@ -6,18 +6,14 @@ dependencies {
   testCompile project(':analyzer')
 }
 
-apply plugin: 'application'
+ext.mainClassName = "edu.kaist.algo.client.GcToolClient"
 
-mainClassName = "edu.kaist.algo.client.GcToolClient"
-
-task logUploadClient(type: CreateStartScripts) {
-  mainClassName = "edu.kaist.algo.client.GcToolClient"
-  applicationName = "GcTool-Client"
-  outputDir = new File(project.buildDir, 'tmp')
-  classpath = jar.outputs.files + project.configurations.runtime
+jar {
+  manifest {
+    attributes "Main-Class": "$mainClassName"
+  }
+  from {
+    configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+  }
 }
 
-applicationDistribution.into("bin") {
-  from(logUploadClient)
-  fileMode = 0755
-}


### PR DESCRIPTION
Change the package method from the `application` plugin to the fat-jar. The jar file would be located in `cli-client/build/libs/`. The usage is like below:

``` bash
$ java -jar cli-client-0.1.0-SNAPSHOT.jar -f ~/Downloads/hotspot_short.log -h localhost -p 50051
$ java -jar cli-client-0.1.0-SNAPSHOT.jar -rd 1 -h localhost -p 50051
```
