### PR TITLE
[#57] Disable logging in cli-client.

### DIFF
--- a/cli-client/build.gradle
+++ b/cli-client/build.gradle
@@ -3,6 +3,8 @@ dependencies {
   compile 'commons-cli:commons-cli:1.3.1'
   compile 'commons-io:commons-io:2.4'
   compile 'com.jakewharton.fliptables:fliptables:1.0.2'
+  compile 'org.slf4j:jul-to-slf4j:1.7.21'
+  compile 'org.slf4j:slf4j-nop:1.7.21'
   testCompile project(':analyzer')
 }
 

--- a/cli-client/src/main/java/edu/kaist/algo/client/GcToolClient.java
+++ b/cli-client/src/main/java/edu/kaist/algo/client/GcToolClient.java
@@ -13,6 +13,7 @@ import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
 import org.apache.commons.io.FileUtils;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -289,6 +290,10 @@ public class GcToolClient {
    * @param args argument of clients
    */
   public static void main(String[] args) {
+    // since grpc uses j.u.l logger, redirect j.u.l to slf4j
+    SLF4JBridgeHandler.removeHandlersForRootLogger();
+    SLF4JBridgeHandler.install();
+
     // parse command-line options
     final Options options = makeOptions();
     final ParsedOptions parsedOptions = parseOptions(options, args);


### PR DESCRIPTION
Disabled grpc logging in cli-client. grpc logger uses JUL (java.util.logging) logger and JUL logger setting is not portable to use. It requires the logging configuration file on `lib/logging.properties` at JRE directory, or the location of the file should be provided as system properties.

I redirected JUL logging to SLF4J by the bridge artifact, and used logback for the logging engine, but there is an issue to find `logback.xml` file in the jar. So, I just disabled all logging function by including sl4j-nop.
